### PR TITLE
fix z-index

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -585,7 +585,7 @@ li.task-completed .task-note-block .task-note { text-decoration:line-through; }
 	background-position: 0 -28px;
 	height: 14px;
 	top: -11px;
-	z-index: 1000;
+	z-index: 100;
 }
 
 .task-comment-block ul li.existingcomment .subicon {


### PR DESCRIPTION
z-index for .task-comment-block ul li.newcomment .subicon is to high.

so the icon shows up in dropmenu (see screenshot)
